### PR TITLE
Update session_manager.lua

### DIFF
--- a/scripts/mods/Power_DI/modules/session_manager.lua
+++ b/scripts/mods/Power_DI/modules/session_manager.lua
@@ -48,7 +48,7 @@ session_manager.new = function()
         )
     end
 
-    session.info.difficulty = state_manager.difficulty and state_manager.difficulty:get_difficulty() or nil
+    session.info.difficulty = state_manager.difficulty and state_manager.difficulty:get_initial_challenge() or nil
     --session.info.date = os.date("%d/%m/%Y")
     session.info.start_time = os.time()
     session.info.resumed = false


### PR DESCRIPTION
The get_difficulty method of the DifficultyManager class was renamed to get_initial_challenge but it returns the same value.